### PR TITLE
Prevent failure with virtual models

### DIFF
--- a/pytest_djangoapp/plugin.py
+++ b/pytest_djangoapp/plugin.py
@@ -30,7 +30,7 @@ def pytest_runtest_teardown(item, nextitem):
         # e.g. in case of mark.skipif
         return
 
-    call_command('flush', interactive=False)
+    call_command('flush', interactive=False, reset_sequences=False)
     teardown_databases(old_config)
 
 


### PR DESCRIPTION
Set `reset_sequences=False` when invoking `flush`.
This has the effect of reproducing Django 3.0+ behaviour
on lower versions of Django.

Closes https://github.com/idlesign/pytest-djangoapp/issues/7