### PR TITLE
SettingsProxy: Allow getattr

### DIFF
--- a/pytest_djangoapp/fixtures/settings.py
+++ b/pytest_djangoapp/fixtures/settings.py
@@ -38,6 +38,9 @@ def settings():
     proxy.restore_initial()
 
 
+_PROXY_SETTING_ATTRS = '_settings', '_overridden'
+
+
 class SettingsProxy(object):
 
     def __init__(self):
@@ -46,10 +49,20 @@ class SettingsProxy(object):
 
     def __setattr__(self, name, value):
 
-        if name in {'_settings', '_overridden'}:
+        if name in _PROXY_SETTING_ATTRS:
             return super(SettingsProxy, self).__setattr__(name, value)
 
         self._set(name, value)
+
+    def __getattr__(self, name):
+
+        if name in _PROXY_SETTING_ATTRS:
+            return super(SettingsProxy, self).__getattr__(name)
+
+        try:
+            return getattr(self._overridden, name)
+        except AttributeError:
+            return getattr(self._settings, name)
 
     def __call__(self, **kwargs):
         # Aid context manager mode.

--- a/pytest_djangoapp/tests/test_fixtures_settings.py
+++ b/pytest_djangoapp/tests/test_fixtures_settings.py
@@ -9,9 +9,17 @@ def test_settings(settings):
         'SOMENEW': 'value',
     })
 
+    assert settings.DEBUG
+    assert settings.SOMENEW == 'value'
+
     assert _actual_settings.DEBUG
+    assert _actual_settings.SOMENEW == 'value'
 
     settings.SOMENEW = 'other'
+
+    assert settings.SOMENEW == 'other'
+
+    assert _actual_settings.SOMENEW == 'other'
 
 
 def test_context_manager(settings):
@@ -20,6 +28,9 @@ def test_context_manager(settings):
     assert not _actual_settings.DEBUG
 
     with settings(SOME=1, DEBUG=True):
+        assert settings.SOME == 1
+        assert settings.DEBUG
+
         assert _actual_settings.SOME == 1
         assert _actual_settings.DEBUG
 

--- a/pytest_djangoapp/tests/test_fixtures_settings.py
+++ b/pytest_djangoapp/tests/test_fixtures_settings.py
@@ -1,3 +1,4 @@
+import pytest
 
 def test_settings(settings):
     from django.conf import settings as _actual_settings
@@ -34,10 +35,58 @@ def test_context_manager(settings):
         assert _actual_settings.SOME == 1
         assert _actual_settings.DEBUG
 
-    assert not hasattr(_actual_settings, 'SOME')
+        settings.OTHER = 1
+        assert settings.OTHER == 1
+        assert _actual_settings.OTHER == 1
+
+    assert not hasattr(settings, 'SOME')
+    assert not hasattr(settings, 'OTHER')
+
     assert not _actual_settings.DEBUG
+    assert not hasattr(_actual_settings, 'SOME')
+    assert not hasattr(_actual_settings, 'OTHER')
 
     assert 'django.contrib.sites' in _actual_settings.INSTALLED_APPS
     assert 'django.contrib.sessions.middleware.SessionMiddleware' in _actual_settings.MIDDLEWARE
     assert 'django.contrib.sessions.middleware.SessionMiddleware' in _actual_settings.MIDDLEWARE_CLASSES
     assert 'dummy' in _actual_settings.DATABASES
+
+    settings.DEBUG = False
+
+    assert not _actual_settings.DEBUG
+
+    settings.SOME = 2
+
+    assert settings.SOME == 2
+
+    assert _actual_settings.SOME == 2
+
+    with settings(SOME='value', DEBUG=True):
+        assert settings.SOME == 'value'
+        assert settings.DEBUG
+
+        assert _actual_settings.SOME == 'value'
+        assert _actual_settings.DEBUG
+
+    assert not settings.DEBUG
+    assert not _actual_settings.DEBUG
+
+    # SOME from before the context manager is now removed.
+    assert not hasattr(settings, 'SOME')
+    assert not hasattr(_actual_settings, 'SOME')
+
+    with settings:
+        settings.OTHER = 1
+        assert settings.OTHER == 1
+        assert _actual_settings.OTHER == 1
+
+    assert not _actual_settings.DEBUG
+
+    assert not hasattr(settings, 'SOME')
+    assert not hasattr(settings, 'OTHER')
+
+    assert not hasattr(_actual_settings, 'SOME')
+    assert not hasattr(_actual_settings, 'OTHER')
+
+    settings.OTHER = 1
+    assert settings.OTHER == 1


### PR DESCRIPTION
Attributes of the django global settings could be read,
however attributes of the settings proxy itself could
not accessed.  That requires that test logic imports
global settings in addition to using a pytest fixture.

Fixes #14