### PR TITLE
Pass verbose command line parameter to runner.verbosity

### DIFF
--- a/pytest_djangoapp/plugin.py
+++ b/pytest_djangoapp/plugin.py
@@ -41,3 +41,4 @@ def pytest_configure(config):
 
     django_settings.configure(**settings_dict)
     django.setup()
+    runner.verbosity = config.option.verbose


### PR DESCRIPTION
DiscoverRunner currently instantiated with verbosity hardcoded to 0.